### PR TITLE
Add nightly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
               run: |
                   ./gradlew build
             - name: Ballerina Build
-              uses: ballerina-platform/ballerina-action/@master
+              uses: ballerina-platform/ballerina-action/@nightly
               with:
                   args: build -c
               env:

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -1,0 +1,62 @@
+name: Daily build
+
+# Controls when the action will run.
+on: 
+  schedule:
+    - cron: '30 2 * * *'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+    # This workflow contains a single job called "build"
+    build:
+        # The type of runner that the job will run on
+        runs-on: ubuntu-latest
+
+        # Steps represent a sequence of tasks that will be executed as part of the job
+        steps:
+            # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+            - uses: actions/checkout@v2
+
+            # Set up Java Environment
+            - name: Set up JDK 11
+              uses: actions/setup-java@v1
+              with:
+                java-version: 11
+
+            # Grant execute permission to the gradlew script
+            - name: Grant execute permission for gradlew
+              run: chmod +x gradlew
+
+            # Build the project with Gradle
+            - name: Build with Gradle
+              env:
+                packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+                packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+                JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
+              run: |
+                ./gradlew build
+            # Build the ballerina project
+            - name: Ballerina Build
+              uses: ballerina-platform/ballerina-action/@nightly
+              with:
+                  args:
+                      build -c --skip-tests
+              env:
+                WORKING_DIR: ./calendar
+                JAVA_HOME: /usr/lib/jvm/default-jvm
+                CLIENT_ID: ${{ secrets.CLIENT_ID }}
+                CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+                REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+                REFRESH_URL: ${{ secrets.REFRESH_URL }}
+                ADDRESS: ${{ secrets.ADDRESS }}
+
+            # Publish Github Package
+            - name: Publish Github Package
+              env:
+                packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+                packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+                publishUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+                publishPAT: ${{ secrets.CONNECTOR_PUBLISH_PAT }}
+                JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
+              run: |
+                ./gradlew publish

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ jobs:
               run: |
                   ./gradlew build
             - name: Ballerina Build
-              uses: ballerina-platform/ballerina-action/@master
+              uses: ballerina-platform/ballerina-action/@nightly
               with:
                   args: build -c --skip-tests
               env:

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,61 @@ subprojects {
     }
 }
 
+def artifactCacheParent = file("${project.projectDir}/build/cache_parent/")
+def packageName = "googleapis.calendar"
+def packageOrg = "ballerinax"
+def pathToBala = file("${project.projectDir}/calendar/target/bala")
+def platform = "java11"
+
+task createBalaDirectory {
+    mkdir "${project.projectDir}/calendar/target/bala"
+}
 
 task build {
     dependsOn('calendar:build')
 }
+
+task copyDistribution {
+    inputs.dir file(project.projectDir)
+
+    pathToBala.eachFileMatch(~/.*.bala/) { balaFile ->
+        copy {
+            from zipTree(balaFile)
+            into file("${artifactCacheParent}/bala/${packageOrg}/${packageName}/${project.version}/${platform}")
+        }
+    }
+    copy {
+        from file("${project.projectDir}/calendar/target/cache")
+        exclude '**/*-testable.jar'
+        exclude '**/tests_cache/'
+        into file("${artifactCacheParent}/cache/")
+    }
+    outputs.dir artifactCacheParent
+}
+
+task createArtifactZip(type: Zip) {
+   from "${buildDir}/cache_parent"
+   archiveName 'distribution.zip'
+   destinationDir(file("${buildDir}/distribution"))
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifact source: createArtifactZip, extension: 'zip'
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/ballerina-platform/module-ballerinax-googleapis.calendar")
+            credentials {
+                username = System.getenv("publishUser")
+                password = System.getenv("publishPAT")
+            }
+        }
+    }
+}
+
+publish.dependsOn copyDistribution

--- a/calendar/Ballerina.toml
+++ b/calendar/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org= "ballerinax"
 name= "googleapis.calendar"
-version= "0.1.5"
+version= "0.1.6-SNAPSHOT"
 export= ["googleapis.calendar", "googleapis.calendar.listener"]
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
@@ -9,7 +9,7 @@ keywords = ["google", "calendar"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-googleapis.calendar"
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-0.1.5.jar"
+path = "../java-wrapper/build/libs/java-wrapper-0.1.6-SNAPSHOT.jar"
 groupId = "org.ballerinalang.googleapis.calendar"
 artifactId = "java-wrapper"
-version = "0.1.5"
+version = "0.1.6-SNAPSHOT"

--- a/calendar/Dependencies.toml
+++ b/calendar/Dependencies.toml
@@ -1,41 +1,36 @@
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-alpha8"
+version = "1.1.0-beta.1"
 
 [[dependency]]
 org = "ballerina"
 name = "time"
-version = "2.0.0-alpha9"
+version = "2.0.0-beta.1"
 
 [[dependency]]
 org = "ballerina"
 name = "log"
-version = "1.1.0-alpha8"
+version = "1.1.0-beta.1"
 
 [[dependency]]
 org = "ballerina"
 name = "url"
-version = "1.1.0-alpha8"
+version = "1.1.0-beta.1"
 
 [[dependency]]
 org = "ballerina"
 name = "os"
-version = "0.8.0-alpha8"
-
-[[dependency]]
-org = "ballerina"
-name = "test"
-version = "0.0.0"
+version = "0.8.0-beta.1"
 
 [[dependency]]
 org = "ballerina"
 name = "uuid"
-version = "0.10.0-alpha8"
+version = "0.10.0-beta.1"
 
 [[dependency]]
 org = "ballerina"
 name = "task"
-version = "2.0.0-alpha9"
+version = "2.0.0-beta.1"
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.googleapis.calendar
-version=0.1.5
-ballerinaLangVersion=2.0.0-alpha8-20210423-135000-530658ec
+version=0.1.6-SNAPSHOT
+ballerinaLangVersion=2.0.0-beta.1-20210511-182300-9317c52a


### PR DESCRIPTION
## Purpose
> Fix https://github.com/wso2-enterprise/choreo/issues/4151

## Goals
-  Bump the dependency versions to SLBeta1 versions
-  Enable nightly build for the connector
-  Publish as a Github Package daily after the daily build

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Swan Lake Beta1