### PR TITLE
Fix warning messages

### DIFF
--- a/calendar/modules/listener/watch_scheduler.bal
+++ b/calendar/modules/listener/watch_scheduler.bal
@@ -66,7 +66,7 @@ class Job {
         decimal timeDifference = (self.'listener.expirationTime/1000) - (<decimal>currentUtc[0]) - 60;
         time:Utc scheduledUtcTime = time:utcAddSeconds(currentUtc, timeDifference);
         time:Civil scheduledTime = time:utcToCivil(scheduledUtcTime);
-        task:JobId result = check task:scheduleOneTimeJob(self, scheduledTime);
+        _ = check task:scheduleOneTimeJob(self, scheduledTime);
         return;
     }
 }

--- a/calendar/tests/test.bal
+++ b/calendar/tests/test.bal
@@ -155,10 +155,10 @@ function testUpdateEvent() {
 @test:Config {
     dependsOn: [testGetEvent, testUpdateEvent]
 }
-function testDeleteEvent() {
+function testDeleteEvent() returns error? {
     log:printInfo("calendarClient -> deleteEvent()");
     error? res = calendarClient->deleteEvent(testCalendarId, testEventId);
-    error? resp = calendarClient->deleteEvent(testCalendarId, testQuickAddEventId);
+    _ = check calendarClient->deleteEvent(testCalendarId, testQuickAddEventId);
     if (res is error) {
         test:assertFail(res.message());
     }


### PR DESCRIPTION
# Description
- Fix the following warning messages in the build
```
Compiling source
	ballerinax/googleapis.calendar:2.0.0
WARNING [tests/test.bal:(161:5,161:84)] unused variable 'resp'
WARNING [watch_scheduler.bal:(69:9,69:80)] unused variable 'result'
```
- Fix https://github.com/ballerina-platform/ballerina-extended-library/issues/199

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
