### PR TITLE
Add dependency to generate pom file for maven publication

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -95,5 +95,6 @@ clean {
     delete 'build'
 }
 
+build.dependsOn "generatePomFileForMavenPublication"
 publishToMavenLocal.dependsOn build
 publish.dependsOn build


### PR DESCRIPTION
# Description

Fixed the build failure for not including `generatePomFileForMavenPublication` dependency in the gradle build file
https://github.com/ballerina-platform/module-ballerinax-googleapis.calendar/actions/runs/7446717777/job/20257540157