### PR TITLE
Update the documentation in the standard format

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ In order to use the Google Calendar connector, you need to first create the Cale
 
 To use the Google Calendar connector in your Ballerina project, modify the `.bal` file as follows:
 
-### Step 1: Import the package
+### Step 1: Import the module
 
-Import the `ballerinax/googleapis.gcalendar` package into your Ballerina project.
+Import the `ballerinax/googleapis.gcalendar` module.
 
 ```ballerina
 import ballerinax/googleapis.gcalendar;

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -72,9 +72,9 @@ In order to use the Google Calendar connector, you need to first create the Cale
 
 To use the Google Calendar connector in your Ballerina project, modify the `.bal` file as follows:
 
-### Step 1: Import the package
+### Step 1: Import the module
 
-Import the `ballerinax/googleapis.gcalendar` package into your Ballerina project.
+Import the `ballerinax/googleapis.gcalendar` module.
 
 ```ballerina
 import ballerinax/googleapis.gcalendar;

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -72,9 +72,9 @@ In order to use the Google Calendar connector, you need to first create the Cale
 
 To use the Google Calendar connector in your Ballerina project, modify the `.bal` file as follows:
 
-### Step 1: Import the package
+### Step 1: Import the module
 
-Import the `ballerinax/googleapis.gcalendar` package into your Ballerina project.
+Import the `ballerinax/googleapis.gcalendar` module.
 
 ```ballerina
 import ballerinax/googleapis.gcalendar;

--- a/examples/project-management-with-calendar/project-management-with-calendar.md
+++ b/examples/project-management-with-calendar/project-management-with-calendar.md
@@ -4,7 +4,7 @@ Let's explore how Alex, a software developer, leverages the Google Calendar API 
 
 ## Step 1: Import Google Calendar Connector
 
-Alex begins by importing the `ballerinax/googleapis.gcalendar` package.
+Alex begins by importing the `ballerinax/googleapis.gcalendar` module into his Ballerina project.
 
 ```ballerina
 import ballerinax/googleapis.gcalendar;

--- a/examples/work-schedule-management-with-calendar/work-schedule-management-with-calendar.md
+++ b/examples/work-schedule-management-with-calendar/work-schedule-management-with-calendar.md
@@ -4,7 +4,7 @@ Sarah relies on the Google Calendar API to efficiently manage her work schedule.
 
 ## Step 1: Import connector
 
-Import the `ballerinax/googleapis.gcalendar` package.
+Import the `ballerinax/googleapis.gcalendar` module.
 
 ```ballerina
 import ballerinax/googleapis.gcalendar;


### PR DESCRIPTION
# Description
$subject
Here the`package` keyword has been changed to `module` as it is the correct term